### PR TITLE
Fix oclif cna scripts config loading error

### DIFF
--- a/src/commands/cna/add-auth.js
+++ b/src/commands/cna/add-auth.js
@@ -12,10 +12,11 @@ governing permissions and limitations under the License.
 const CNABaseCommand = require('../../CNABaseCommand')
 const path = require('path')
 const fs = require('fs-extra')
-const scripts = require('@adobe/io-cna-scripts')({})
+const CNAScripts = require('@adobe/io-cna-scripts')
 
 class CNAAddAuthCommand extends CNABaseCommand {
   async run () {
+    const scripts = CNAScripts({})
     let manifestFile = path.resolve('./manifest.yml')
     if (!fs.existsSync(manifestFile)) {
       this.error('No manifest found in current folder')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes a missing cna-scripts config error raised by oclif on every `aio` command.

Example of error: 
```
> aio
(node:87070) Error Plugin: @adobe/aio-cli-plugin-cna: Missing aio runtime config (set AIO_RUNTIME_XXX env vars)
module: @oclif/config@1.12.9
task: toCached
plugin: @adobe/aio-cli-plugin-cna
root: /Users/mraho/.aio-cna-repos/aio-cli-plugin-cna
See more details with DEBUG=*
(node:87070) Error Plugin: @adobe/aio-cli-plugin-cna: Missing aio runtime config (set AIO_RUNTIME_XXX env vars)
module: @oclif/config@1.12.9
task: toCached
plugin: @adobe/aio-cli-plugin-cna
root: /Users/mraho/.aio-cna-repos/aio-cli-plugin-cna
See more details with DEBUG=*
Adobe I/O Extensible CLI

VERSION
  @adobe/aio-cli/1.5.1-dev.0 darwin-x64 node-v10.15.3

USAGE
  $ aio [COMMAND]
...
```

<!--- Describe your changes in detail -->


## How Has This Been Tested?
npm run test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
