### PR TITLE
fix typo in init command

### DIFF
--- a/src/commands/cna/init.js
+++ b/src/commands/cna/init.js
@@ -224,7 +224,7 @@ package pre-configured.
     if (!bSkipPrompt) {
       actionQ = await inquirer.prompt([{
         name: 'actionDest',
-        message: 'What folder do you want to use as your public directory?',
+        message: 'What folder do you want to use as your actions directory?',
         type: 'string',
         default: 'actions'
       }])


### PR DESCRIPTION
Small typo fix for the question `What folder do you want to use as your public directory?`, while asking for actions dir. It should be `What folder do you want to use as your actions directory?`.

## Related Issue

https://github.com/adobe/aio-cli-plugin-cna/issues/39

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
