### PR TITLE
deploy only (no build) options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g @adobe/aio-cli-plugin-cna
 $ @adobe/aio-cli-plugin-cna COMMAND
 running command...
 $ @adobe/aio-cli-plugin-cna (-v|--version|version)
-@adobe/aio-cli-plugin-cna/0.2.1 darwin-x64 node-v10.16.1
+@adobe/aio-cli-plugin-cna/0.2.1-dev darwin-x64 node-v10.11.0
 $ @adobe/aio-cli-plugin-cna --help [COMMAND]
 USAGE
   $ @adobe/aio-cli-plugin-cna COMMAND
@@ -36,6 +36,7 @@ USAGE
 * [`@adobe/aio-cli-plugin-cna cna:deploy`](#adobeaio-cli-plugin-cna-cnadeploy)
 * [`@adobe/aio-cli-plugin-cna cna:init [PATH]`](#adobeaio-cli-plugin-cna-cnainit-path)
 * [`@adobe/aio-cli-plugin-cna cna:run [PATH]`](#adobeaio-cli-plugin-cna-cnarun-path)
+* [`@adobe/aio-cli-plugin-cna cna:test [PATH]`](#adobeaio-cli-plugin-cna-cnatest-path)
 * [`@adobe/aio-cli-plugin-cna cna:undeploy [PATH]`](#adobeaio-cli-plugin-cna-cnaundeploy-path)
 
 ## `@adobe/aio-cli-plugin-cna cna:add-auth [PATH]`
@@ -54,7 +55,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/cna/add-auth.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1/src/commands/cna/add-auth.js)_
+_See code: [src/commands/cna/add-auth.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1-dev/src/commands/cna/add-auth.js)_
 
 ## `@adobe/aio-cli-plugin-cna cna:create [PATH]`
 
@@ -72,7 +73,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/cna/create.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1/src/commands/cna/create.js)_
+_See code: [src/commands/cna/create.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1-dev/src/commands/cna/create.js)_
 
 ## `@adobe/aio-cli-plugin-cna cna:deploy`
 
@@ -90,7 +91,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/cna/deploy.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1/src/commands/cna/deploy.js)_
+_See code: [src/commands/cna/deploy.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1-dev/src/commands/cna/deploy.js)_
 
 ## `@adobe/aio-cli-plugin-cna cna:init [PATH]`
 
@@ -109,7 +110,7 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/cna/init.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1/src/commands/cna/init.js)_
+_See code: [src/commands/cna/init.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1-dev/src/commands/cna/init.js)_
 
 ## `@adobe/aio-cli-plugin-cna cna:run [PATH]`
 
@@ -128,7 +129,25 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/cna/run.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1/src/commands/cna/run.js)_
+_See code: [src/commands/cna/run.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1-dev/src/commands/cna/run.js)_
+
+## `@adobe/aio-cli-plugin-cna cna:test [PATH]`
+
+Run a Cloud Native Application
+
+```
+USAGE
+  $ @adobe/aio-cli-plugin-cna cna:test [PATH]
+
+ARGUMENTS
+  PATH  [default: .] Path to the app directory
+
+OPTIONS
+  -e, --e2e      runs e2e tests.
+  -u, --unit     runs unit tests (default).
+  -v, --verbose  Verbose output
+  --version      Show version
+```
 
 ## `@adobe/aio-cli-plugin-cna cna:undeploy [PATH]`
 
@@ -148,5 +167,5 @@ OPTIONS
   --version      Show version
 ```
 
-_See code: [src/commands/cna/undeploy.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1/src/commands/cna/undeploy.js)_
+_See code: [src/commands/cna/undeploy.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1-dev/src/commands/cna/undeploy.js)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ USAGE
 * [`@adobe/aio-cli-plugin-cna cna:deploy`](#adobeaio-cli-plugin-cna-cnadeploy)
 * [`@adobe/aio-cli-plugin-cna cna:init [PATH]`](#adobeaio-cli-plugin-cna-cnainit-path)
 * [`@adobe/aio-cli-plugin-cna cna:run [PATH]`](#adobeaio-cli-plugin-cna-cnarun-path)
-* [`@adobe/aio-cli-plugin-cna cna:test [PATH]`](#adobeaio-cli-plugin-cna-cnatest-path)
 * [`@adobe/aio-cli-plugin-cna cna:undeploy [PATH]`](#adobeaio-cli-plugin-cna-cnaundeploy-path)
 
 ## `@adobe/aio-cli-plugin-cna cna:add-auth [PATH]`
@@ -77,16 +76,17 @@ _See code: [src/commands/cna/create.js](https://github.com/adobe/aio-cli-plugin-
 
 ## `@adobe/aio-cli-plugin-cna cna:deploy`
 
-Builds and deploys a Cloud Native Application
+Build and deploy a Cloud Native Application
 
 ```
 USAGE
   $ @adobe/aio-cli-plugin-cna cna:deploy
 
 OPTIONS
-  -a, --actions  Only deploy actions.
-  -b, --build    Only build, don't deploy.
-  -s, --static   Only deploy static files.
+  -a, --actions  Only build & deploy actions
+  -b, --build    Only build, don't deploy
+  -d, --deploy   Only deploy, don't build
+  -s, --static   Only build & deploy static files
   -v, --verbose  Verbose output
   --version      Show version
 ```
@@ -130,24 +130,6 @@ OPTIONS
 ```
 
 _See code: [src/commands/cna/run.js](https://github.com/adobe/aio-cli-plugin-cna/blob/v0.2.1-dev/src/commands/cna/run.js)_
-
-## `@adobe/aio-cli-plugin-cna cna:test [PATH]`
-
-Run a Cloud Native Application
-
-```
-USAGE
-  $ @adobe/aio-cli-plugin-cna cna:test [PATH]
-
-ARGUMENTS
-  PATH  [default: .] Path to the app directory
-
-OPTIONS
-  -e, --e2e      runs e2e tests.
-  -u, --unit     runs unit tests (default).
-  -v, --verbose  Verbose output
-  --version      Show version
-```
 
 ## `@adobe/aio-cli-plugin-cna cna:undeploy [PATH]`
 

--- a/src/commands/cna/deploy.js
+++ b/src/commands/cna/deploy.js
@@ -56,12 +56,14 @@ class CNADeploy extends CNABaseCommand {
       }
       const scripts = CNAScripts({ listeners })
 
-      // build phase
-      if (!flags.static) {
-        await scripts.buildActions()
-      }
-      if (!flags.actions) {
-        await scripts.buildUI()
+      if (!flags.deploy) {
+        // build phase
+        if (!flags.static) {
+          await scripts.buildActions()
+        }
+        if (!flags.actions) {
+          await scripts.buildUI()
+        }
       }
       // deploy phase
       if (!flags.build) {
@@ -92,15 +94,16 @@ class CNADeploy extends CNABaseCommand {
   }
 }
 
-CNADeploy.description = `Builds and deploys a Cloud Native Application
+CNADeploy.description = `Build and deploy a Cloud Native Application
 `
 
 CNADeploy.flags = {
   ...CNABaseCommand.flags,
-  build: flags.boolean({ char: 'b', description: 'Only build, don\'t deploy.' }),
+  build: flags.boolean({ char: 'b', description: 'Only build, don\'t deploy' }),
+  deploy: flags.boolean({ char: 'd', description: 'Only deploy, don\'t build' }),
   // todo remove these 2 options and autodetect UI/action dir + ui/actions changes
-  static: flags.boolean({ char: 's', description: 'Only deploy static files.', exclusive: ['actions'] }),
-  actions: flags.boolean({ char: 'a', description: 'Only deploy actions.', exclusive: ['static'] })
+  static: flags.boolean({ char: 's', description: 'Only build & deploy static files', exclusive: ['actions'] }),
+  actions: flags.boolean({ char: 'a', description: 'Only build & deploy actions', exclusive: ['static'] })
 
   // todo no color/spinner/open output
   // 'no-fancy': flags.boolean({ description: 'Simple output and no url open' }),

--- a/src/commands/cna/deploy.js
+++ b/src/commands/cna/deploy.js
@@ -99,8 +99,8 @@ CNADeploy.description = `Build and deploy a Cloud Native Application
 
 CNADeploy.flags = {
   ...CNABaseCommand.flags,
-  build: flags.boolean({ char: 'b', description: 'Only build, don\'t deploy' }),
-  deploy: flags.boolean({ char: 'd', description: 'Only deploy, don\'t build' }),
+  build: flags.boolean({ char: 'b', description: 'Only build, don\'t deploy', exclusive: ['deploy'] }),
+  deploy: flags.boolean({ char: 'd', description: 'Only deploy, don\'t build', exclusive: ['build'] }),
   // todo remove these 2 options and autodetect UI/action dir + ui/actions changes
   static: flags.boolean({ char: 's', description: 'Only build & deploy static files', exclusive: ['actions'] }),
   actions: flags.boolean({ char: 'a', description: 'Only build & deploy actions', exclusive: ['static'] })

--- a/test/commands/cna/deploy.test.js
+++ b/test/commands/cna/deploy.test.js
@@ -49,6 +49,10 @@ test('flags', async () => {
   expect(typeof TheCommand.flags.build).toBe('object')
   expect(TheCommand.flags.build.char).toBe('b')
   expect(typeof TheCommand.flags.build.description).toBe('string')
+
+  expect(typeof TheCommand.flags.deploy).toBe('object')
+  expect(TheCommand.flags.deploy.char).toBe('d')
+  expect(typeof TheCommand.flags.deploy.description).toBe('string')
 })
 
 describe('run', () => {
@@ -141,6 +145,50 @@ describe('run', () => {
   })
 
   test('build only actions', async () => {
+    command.argv = ['-ba']
+    await command.run()
+    expect(command.error).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployActions).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployUI).toHaveBeenCalledTimes(0)
+    expect(mockScripts.buildActions).toHaveBeenCalledTimes(1)
+    expect(mockScripts.buildUI).toHaveBeenCalledTimes(0)
+    expect(mockOpen).toHaveBeenCalledTimes(0)
+  })
+
+  test('deploy only', async () => {
+    command.argv = ['-d']
+    await command.run()
+    expect(command.error).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployActions).toHaveBeenCalledTimes(1)
+    expect(mockScripts.deployUI).toHaveBeenCalledTimes(1)
+    expect(mockScripts.buildActions).toHaveBeenCalledTimes(0)
+    expect(mockScripts.buildUI).toHaveBeenCalledTimes(0)
+    expect(mockOpen).toHaveBeenCalledTimes(1)
+  })
+
+  test('deploy only --verbose', async () => {
+    command.argv = ['-d', '--verbose']
+    await command.run()
+    expect(command.error).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployActions).toHaveBeenCalledTimes(1)
+    expect(mockScripts.deployUI).toHaveBeenCalledTimes(1)
+    expect(mockScripts.buildActions).toHaveBeenCalledTimes(0)
+    expect(mockScripts.buildUI).toHaveBeenCalledTimes(0)
+    expect(mockOpen).toHaveBeenCalledTimes(0)
+  })
+
+  test('deploy only static files', async () => {
+    command.argv = ['-ds']
+    await command.run()
+    expect(command.error).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployActions).toHaveBeenCalledTimes(0)
+    expect(mockScripts.deployUI).toHaveBeenCalledTimes(1)
+    expect(mockScripts.buildActions).toHaveBeenCalledTimes(0)
+    expect(mockScripts.buildUI).toHaveBeenCalledTimes(0)
+    expect(mockOpen).toHaveBeenCalledTimes(1)
+  })
+
+  test('deploy only actions', async () => {
     command.argv = ['-ba']
     await command.run()
     expect(command.error).toHaveBeenCalledTimes(0)

--- a/test/commands/cna/deploy.test.js
+++ b/test/commands/cna/deploy.test.js
@@ -49,10 +49,12 @@ test('flags', async () => {
   expect(typeof TheCommand.flags.build).toBe('object')
   expect(TheCommand.flags.build.char).toBe('b')
   expect(typeof TheCommand.flags.build.description).toBe('string')
+  expect(TheCommand.flags.build.exclusive).toEqual(['deploy'])
 
   expect(typeof TheCommand.flags.deploy).toBe('object')
   expect(TheCommand.flags.deploy.char).toBe('d')
   expect(typeof TheCommand.flags.deploy.description).toBe('string')
+  expect(TheCommand.flags.deploy.exclusive).toEqual(['build'])
 })
 
 describe('run', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a deploy only option to the deploy command.

This little change gives users the flexibility to use their own build command while still relying on our deployment process. Likewise a build only options was already provided.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
