### PR TITLE
remove spinner, --verbose means npm --silent=false

### DIFF
--- a/src/commands/cna/test.js
+++ b/src/commands/cna/test.js
@@ -10,9 +10,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const ora = require('ora')
-const chalk = require('chalk')
-
 const { flags } = require('@oclif/command')
 const cnaHelper = require('../../lib/cna-helper')
 const CNABaseCommand = require('../../CNABaseCommand')
@@ -23,25 +20,12 @@ class CNATest extends CNABaseCommand {
     // some things we could do here:
     // test configurations, ie remote-actions deployed and called from local
     // this just runs package.json scripts.test, we could also check that this is in fact a cna project
-
-    const spinner = ora()
-
-    const taskName = flags.e2e ? 'e2e tests' : 'unit tests'
     const command = flags.e2e ? 'e2e' : 'test'
-
-    this.log(chalk.bold(`> ${taskName}`))
-    spinner.start(taskName)
-
     try {
-      await cnaHelper.runPackageScript(command, process.cwd(), { silent: true })
+      await cnaHelper.runPackageScript(command, process.cwd(), { silent: !flags.verbose })
     } catch (e) {
-      this.log()
-      spinner.fail(chalk.bold(chalk.red(`${taskName} failed !`)))
-      return this.error(e, { exit: e.exitCode })
+      return this.error(e.message, { exit: e.exitCode })
     }
-
-    this.log()
-    spinner.succeed(chalk.bold(chalk.green(`${taskName} executed successfully 👌`)))
   }
 }
 

--- a/test/commands/cna/test.test.js
+++ b/test/commands/cna/test.test.js
@@ -90,7 +90,7 @@ describe('run', () => {
     cnaHelper.runPackageScript.mockRejectedValue(error)
     command.argv = argv
     await command.run()
-    expect(command.error).toHaveBeenCalledWith(error, { exit: error.exitCode })
+    expect(command.error).toHaveBeenCalledWith(error.message, { exit: error.exitCode })
   }
 
   test('no flags', () => expectNoErrors([], 'test'))

--- a/test/commands/cna/test.test.js
+++ b/test/commands/cna/test.test.js
@@ -46,6 +46,7 @@ describe('Command Prototype', () => {
     expect(typeof TheCommand.flags.e2e.description).toBe('string')
     expect(TheCommand.flags.e2e.exclusive).toEqual(['unit'])
   })
+
   describe('bad flags', () => {
     const expectFlagError = async (argv, message) => {
       const command = new TheCommand([])
@@ -102,4 +103,40 @@ describe('run', () => {
   test('-e fails', () => expectErrors(['-e']))
   test('--unit fails', () => expectErrors(['--unit']))
   test('-u fails', () => expectErrors(['-u']))
+
+  test('verbose flag', async () => {
+    command.argv = ['--verbose']
+    await command.run()
+    expect(cnaHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+  })
+
+  test('-v flag', async () => {
+    command.argv = ['-v']
+    await command.run()
+    expect(cnaHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+  })
+
+  test('--verbose --unit flag', async () => {
+    command.argv = ['--verbose', '--unit']
+    await command.run()
+    expect(cnaHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+  })
+
+  test('-v -u flags', async () => {
+    command.argv = ['-v', '-u']
+    await command.run()
+    expect(cnaHelper.runPackageScript).toHaveBeenCalledWith('test', expect.any(String), { silent: false })
+  })
+
+  test('--verbose --e2e flag', async () => {
+    command.argv = ['--verbose', '--e2e']
+    await command.run()
+    expect(cnaHelper.runPackageScript).toHaveBeenCalledWith('e2e', expect.any(String), { silent: false })
+  })
+
+  test('-v -e flags', async () => {
+    command.argv = ['-v', '-e']
+    await command.run()
+    expect(cnaHelper.runPackageScript).toHaveBeenCalledWith('e2e', expect.any(String), { silent: false })
+  })
 })


### PR DESCRIPTION
spinner was getting muxed with npm output, between pretest, test, and posttest
Removed redundant output

verbose flag means npm run is called with --silent=false

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
